### PR TITLE
Fix references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,11 @@ export default class MyComponent extends Component {
 }
 ```
 
-#### UMD module:
-Include `dist/standalone/Typist.js` into your build, using whatever build tool
-or manually entering a `<script>` tag.
-
 <a name="cssBlink"></a>
 #### CSS
 Typist contains a simple CSS file to make the cursor at the end of the text
 blink. To include it, you must include
-[`dist/Typist.css`](/dist/Typist.css) in your build.
-
+[`src/Cursor.scss`](/src/Cursor.scss) in your build.
 
 ## Children
 Typist will animate any text present in its descendents. Each text


### PR DESCRIPTION
### Overview
This PR introduces changes to the `README.md`:
+ Removes reference for UMD module
+ Fixes reference for blinking animation stylesheet

<br />

Also, I'm working with a project that's not using `sass`, so I just used the compiled version directly:
```css
.Typist .Cursor {
  display: inline-block;
}

.Typist .Cursor--blinking {
  opacity: 1;
  animation: blink 1s linear infinite;
}

@keyframes blink {
  0% {
    opacity: 1;
  }
  50% {
    opacity: 0;
  }
  100% {
    opacity: 1;
  }
}
```

Thanks again for the package — cheers!