### PR TITLE
Use a static property to detect `Backspace` and `Delay` elements

### DIFF
--- a/src/Backspace.jsx
+++ b/src/Backspace.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 const Backspace = () => <noscript />;
 
+Backspace.componentName = 'Backspace';
+
 Backspace.propTypes = {
   count: PropTypes.number,
   delay: PropTypes.number,

--- a/src/Delay.jsx
+++ b/src/Delay.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 
 const Delay = () => <noscript />;
 
+Delay.componentName = 'Delay';
+
 Delay.propTypes = {
   ms: PropTypes.number.isRequired,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import Backspace from './Backspace';
-import Delay from './Delay';
 
 export const sleep = (val) => new Promise((resolve) => (
   val != null ? setTimeout(resolve, val) : resolve()
@@ -34,11 +32,11 @@ export function exclude(obj, keys) {
 }
 
 export function isBackspaceElement(element) {
-  return element && element.type === Backspace;
+  return element && element.type && element.type.componentName === 'Backspace';
 }
 
 export function isDelayElement(element) {
-  return element && element.type === Delay;
+  return element && element.type && element.type.componentName === 'Delay';
 }
 
 export function extractTextFromElement(element) {


### PR DESCRIPTION
It's related to [this commit](https://github.com/jstejada/react-typist/commit/d122bd19e3d22a19ea5f38744f3e46950581c241)

Comparing reference type of `Backspace` and `Delay` doesn't work with `react-hot-loader`. I use [next.js](https://github.com/zeit/next.js/) and it's using `react-hot-loader` in the background and I have same issue as #33. cause of the problem is this:

> Because React Hot Loader creates proxied versions of your components, comparing reference types of elements won't work
https://github.com/gaearon/react-hot-loader#checking-element-types

It's a known issue of `react-hot-loader` and it seems that it's not going to be fixed from their side: https://github.com/gaearon/react-hot-loader/issues/304

The only solution that I found (for libraries) is to define a static property for each components and then compare them.

I used `componentName` property and it's working on both next.js and minified version.

