### PR TITLE
added ability to turn cursor fade off

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -22,6 +22,9 @@ class TypistExample extends React.Component {
           avgTypingSpeed={40}
           startDelay={2000}
           onTypingDone={this.onHeaderTyped}
+          cursor={{
+            fade: false,
+          }}
         >
           <a href={docs}>React Typist</a>
         </Typist>
@@ -29,7 +32,9 @@ class TypistExample extends React.Component {
           {this.state.renderMsg ? (
             <Typist
               className="TypistExample-message"
-              cursor={{ hideWhenDone: true }}
+              cursor={{
+                hideWhenDone: true,
+              }}
             >
               * Easy to style
               <Typist.Delay ms={1250} />

--- a/src/Cursor.jsx
+++ b/src/Cursor.jsx
@@ -7,6 +7,7 @@ export default class Cursor extends Component {
 
   static propTypes = {
     blink: PropTypes.bool,
+    fade: PropTypes.bool,
     show: PropTypes.bool,
     element: PropTypes.node,
     hideWhenDone: PropTypes.bool,
@@ -16,6 +17,7 @@ export default class Cursor extends Component {
 
   static defaultProps = {
     blink: true,
+    fade: true,
     show: true,
     element: '|',
     hideWhenDone: false,
@@ -70,7 +72,9 @@ export default class Cursor extends Component {
 
   render() {
     if (this.state.shouldRender) {
-      const className = this.props.blink ? ' Cursor--blinking' : '';
+      const className = this.props.blink ?
+        ` Cursor--blinking${this.props.fade ? '--fade' : ''}` :
+        '';
       return (
         <span className={`Cursor${className}`}>
           {this.props.element}

--- a/src/Cursor.scss
+++ b/src/Cursor.scss
@@ -2,13 +2,18 @@
 .Typist .Cursor {
   display: inline-block;
 
-  &--blinking {
+  &[class*='--blinking'] {
     opacity: 1;
-    animation: blink 1s linear infinite;
+    animation: blink 1s step-end infinite;
     @keyframes blink {
       0% { opacity:1; }
       50% { opacity:0; }
       100% { opacity:1; }
     }
   }
+
+  &[class*='--fade'] {
+    animation: blink 1s linear infinite;
+  }
+
 }


### PR DESCRIPTION
As per issue https://github.com/jstejada/react-typist/issues/51 added ability to toggle cursor fade