### PR TITLE
Add style attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Typing animations with React",
   "main": "dist/Typist.js",
   "files": ["dist", "src"],
+  "style": "dist/Typist.css",
   "scripts": {
     "dist": "webpack --config webpack.dist.config.js",
     "standalone": "webpack --config webpack.standalone.config.js",


### PR DESCRIPTION
This change enables `postcss-import` and other tools to infer which CSS file is the correct one to import when referencing the module name. This means users can do `@import 'react-typist;` and it will import the correct stylesheet. This change should make it a _little_ bit easier for people to get started using `react-typist`.

More on the `style` attribute: https://jaketrent.com/post/package-json-style-attribute/