### PR TITLE
Fix invalid example prop name

### DIFF
--- a/examples/index.js
+++ b/examples/index.js
@@ -4,7 +4,6 @@ import Typist from 'Typist';
 import './main.scss';
 
 class TypistExample extends React.Component {
-
   state = {
     renderMsg: false,
   }
@@ -19,7 +18,7 @@ class TypistExample extends React.Component {
       <div className="TypistExample">
         <Typist
           className="TypistExample-header"
-          avgTypingSpeed={40}
+          avgTypingDelay={40}
           startDelay={2000}
           onTypingDone={this.onHeaderTyped}
         >


### PR DESCRIPTION
Fix typo on the props for `avgTypingDelay` in the example file.