### PR TITLE
prevent setting state when component not mounted

### DIFF
--- a/src/Typist.jsx
+++ b/src/Typist.jsx
@@ -172,6 +172,11 @@ export default class Typist extends Component {
           textLines[lineIdx] += character;
         }
 
+        if (!this.mounted) {
+          resolve();
+          return;
+        }
+
         this.setState({ textLines }, () => {
           const delay = this.delayGenerator(line, lineIdx, character, charIdx);
           onCharacterTyped(character, charIdx);


### PR DESCRIPTION
I was having issues using this component with [react-router](https://github.com/ReactTraining/react-router). Whenever I navigated away from the page, my Typist component was unmounted (as expected) and a few seconds later the console logged the following warning:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.
    in Typist (created by TopSection)
    in h1 (created by TopSection)
    in div (created by TopSection)
    in div (created by FlexContainer)
    in FlexContainer (created by TopSection)
    in div (created by TopSection)
    in TopSection (created by Landing)
    in div (created by Landing)
    in Landing (created by Context.Consumer)
```

I added an additional check inside one of the `setTimeout` handlers, before trying to set the state of the unmounted component.