### PR TITLE
Fix semver typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "^0.14 || ^15.0 || ^16.0",
-    "react-dom": "^^0.14 || ^15.0 || ^16.0"
+    "react-dom": "^0.14 || ^15.0 || ^16.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.3",


### PR DESCRIPTION
This seems to be an unintended typo for a semver version, which can break some package managers.